### PR TITLE
have_errors, negated

### DIFF
--- a/lib/rspec/graphql_response/matchers/have_errors.rb
+++ b/lib/rspec/graphql_response/matchers/have_errors.rb
@@ -15,8 +15,20 @@ RSpec::GraphQLResponse.add_matcher :have_errors do |count = nil|
     @result.reason
   end
 
+  match_when_negated do |response|
+    have_errors = RSpec::GraphQLResponse.validator(:have_errors)
+
+    @result = have_errors.validate_negated(
+      response,
+      expected_count: count,
+      expected_messages: @messages
+    )
+
+    @result.valid?
+  end
+
   failure_message_when_negated do |response|
-    @result.negated_reason
+    @result.reason
   end
 
   chain :with_messages do |*messages|

--- a/lib/rspec/graphql_response/validators/have_errors.rb
+++ b/lib/rspec/graphql_response/validators/have_errors.rb
@@ -29,13 +29,13 @@ RSpec::GraphQLResponse.add_validator :have_errors do
     pass_validation 
   end
 
-  failure_message_negated :nil, "Cannot evaluate nil for errors"
-  failure_message_negated :none, ->(actual) { "Expected response not to have errors, but found\n\t#{actual.inspect}" }
-  failure_message_negated :unmatched, ->(expected, actual) { "Expected not to find any of\n\t#{expected.inspect}\nbut found\n\t#{actual.inspect}" }
-  failure_message_negated :length, ->(expected, actual, messages) { "Expected response not to have #{expected} errors, but found #{actual}\n\t#{messages.inspect}" }
+  failure_message :negated_nil, "Cannot evaluate nil for errors"
+  failure_message :negated_none, ->(actual) { "Expected response not to have errors, but found\n\t#{actual.inspect}" }
+  failure_message :negated_unmatched, ->(expected, actual) { "Expected not to find any of\n\t#{expected.inspect}\nbut found\n\t#{actual.inspect}" }
+  failure_message :negated_length, ->(expected, actual, messages) { "Expected response not to have #{expected} errors, but found #{actual}\n\t#{messages.inspect}" }
 
   validate_negated do |response, expected_messages: nil, expected_count: nil|
-    next fail_validation(:nil) if response.nil?
+    next fail_validation(:negated_nil) if response.nil?
 
     errors = response.fetch("errors", [])
     actual_messages = errors.map {|e| e["message"] }
@@ -45,12 +45,12 @@ RSpec::GraphQLResponse.add_validator :have_errors do
     with_count = !expected_count.nil?
 
     if !with_count && !with_messages && actual_count != 0
-      next fail_validation(:none, actual_messages)
+      next fail_validation(:negated_none, actual_messages)
     end
 
     if with_count
       if expected_count == actual_count
-        next fail_validation(:length, expected_count, actual_count, actual_messages)
+        next fail_validation(:negated_length, expected_count, actual_count, actual_messages)
       elsif !with_messages
         next pass_validation
       end
@@ -58,7 +58,7 @@ RSpec::GraphQLResponse.add_validator :have_errors do
 
     if with_messages
       unmatched_messages = expected_messages & actual_messages
-      next fail_validation(:unmatched, expected_messages, unmatched_messages) if unmatched_messages.any?
+      next fail_validation(:negated_unmatched, expected_messages, unmatched_messages) if unmatched_messages.any?
     end
 
     if with_messages || with_count

--- a/lib/rspec/graphql_response/validators/have_errors.rb
+++ b/lib/rspec/graphql_response/validators/have_errors.rb
@@ -4,16 +4,13 @@ RSpec::GraphQLResponse.add_validator :have_errors do
   failure_message :unmatched, ->(expected, actual) { "Expected\n\t#{expected.inspect}\nbut found\n\t#{actual.inspect}" }
   failure_message :length, ->(expected, actual) { "Expected response to have #{expected} errors, but found #{actual}" }
 
-  failure_message_negated :nil, "Cannot evaluate nil for errors"
-  failure_message_negated :none, ->(actual) { "Expected response not to have errors, but found\n\t#{actual.inspect}" }
-  failure_message_negated :unmatched, ->(expected, actual) { "Expected not to find\n\t#{expected.inspect}\nbut found\n\t#{actual.inspect}" }
-  failure_message_negated :length, ->(expected, actual) { "Expected response not to have #{expected} errors, but found #{actual}" }
-
   validate do |response, expected_messages: nil, expected_count: nil|
     next fail_validation(:nil) if response.nil?
 
     errors = response.fetch("errors", [])
-    next fail_validation(:none, errors) if errors.length == 0
+    actual_messages = errors.map {|e| e["message"] }
+
+    next fail_validation(:none, actual_messages) if errors.length == 0
 
     with_messages = Array(expected_messages).length > 0
     with_count = !expected_count.nil?
@@ -24,7 +21,6 @@ RSpec::GraphQLResponse.add_validator :have_errors do
     end
 
     if with_messages
-      actual_messages = errors.map {|e| e["message"] }
       unmatched_messages = expected_messages.difference(actual_messages)
 
       next fail_validation(:unmatched, expected_messages, actual_messages) if unmatched_messages.any?
@@ -33,26 +29,41 @@ RSpec::GraphQLResponse.add_validator :have_errors do
     pass_validation 
   end
 
+  failure_message_negated :nil, "Cannot evaluate nil for errors"
+  failure_message_negated :none, ->(actual) { "Expected response not to have errors, but found\n\t#{actual.inspect}" }
+  failure_message_negated :unmatched, ->(expected, actual) { "Expected not to find any of\n\t#{expected.inspect}\nbut found\n\t#{actual.inspect}" }
+  failure_message_negated :length, ->(expected, actual, messages) { "Expected response not to have #{expected} errors, but found #{actual}\n\t#{messages.inspect}" }
+
   validate_negated do |response, expected_messages: nil, expected_count: nil|
     next fail_validation(:nil) if response.nil?
 
     errors = response.fetch("errors", [])
+    actual_messages = errors.map {|e| e["message"] }
+    actual_count = errors.length
+
     with_messages = Array(expected_messages).length > 0
     with_count = !expected_count.nil?
 
+    if !with_count && !with_messages && actual_count != 0
+      next fail_validation(:none, actual_messages)
+    end
+
     if with_count
-      actual_count = errors.length
-      next fail_validation(:length, expected_count, actual_count) if expected_count == actual_count
+      if expected_count == actual_count
+        next fail_validation(:length, expected_count, actual_count, actual_messages)
+      elsif !with_messages
+        next pass_validation
+      end
     end
 
     if with_messages
-      actual_messages = errors.map {|e| e["message"] }
-      unmatched_messages = expected_messages.difference(actual_messages)
-
-      next fail_validation(:unmatched, expected_messages, actual_messages) unless unmatched_messages.any?
+      unmatched_messages = expected_messages & actual_messages
+      next fail_validation(:unmatched, expected_messages, unmatched_messages) if unmatched_messages.any?
     end
 
-    next fail_validation(:none, errors) if errors.length != 0
+    if with_messages || with_count
+      next pass_validation
+    end
 
     pass_validation 
   end

--- a/lib/rspec/graphql_response/validators/validation_base.rb
+++ b/lib/rspec/graphql_response/validators/validation_base.rb
@@ -8,11 +8,6 @@ module RSpec
             @messages[type] = msg
           end
 
-          def failure_message_negated(type, msg)
-            @negated_messages ||= {}
-            @negated_messages[type] = msg
-          end
-
           def validate(&validate_method)
             @validate_method = validate_method
           end
@@ -38,10 +33,6 @@ module RSpec
 
         def failure_message(type)
           self.class.instance_variable_get(:@messages)[type]
-        end
-
-        def failure_message_negated(type)
-          self.class.instance_variable_get(:@negated_messages)[type]
         end
       end
     end

--- a/lib/rspec/graphql_response/validators/validation_base.rb
+++ b/lib/rspec/graphql_response/validators/validation_base.rb
@@ -13,16 +13,27 @@ module RSpec
             @negated_messages[type] = msg
           end
 
-          def validate(&validation_method)
-            @validation_method = validation_method
+          def validate(&validate_method)
+            @validate_method = validate_method
+          end
+
+          def validate_negated(&validate_negated_method)
+            @validate_negated_method = validate_negated_method
           end
         end
 
         def validate(response, *args)
-          validation_method = self.class.instance_variable_get(:@validation_method)
+          validate_method = self.class.instance_variable_get(:@validate_method)
 
           runner = ValidationRunner.new(self)
-          runner.instance_exec(response, *args, &validation_method)
+          runner.instance_exec(response, *args, &validate_method)
+        end
+
+        def validate_negated(response, *args)
+          validate_negated_method = self.class.instance_variable_get(:@validate_negated_method)
+
+          runner = ValidationRunner.new(self)
+          runner.instance_exec(response, *args, &validate_negated_method)
         end
 
         def failure_message(type)

--- a/lib/rspec/graphql_response/validators/validation_result.rb
+++ b/lib/rspec/graphql_response/validators/validation_result.rb
@@ -6,8 +6,8 @@ module RSpec
           self.new(true)
         end
 
-        def self.fail(reason, negated_reason, args)
-          self.new(false, reason, negated_reason, args)
+        def self.fail(reason, args)
+          self.new(false, reason, args)
         end
 
         def valid?
@@ -22,20 +22,11 @@ module RSpec
           @reason
         end
 
-        def negated_reason
-          if @negated_reason.is_a? Proc
-            @negated_reason = @negated_reason.call(*@args)
-          end
-
-          @negated_reason
-        end
-
         private
 
-        def initialize(is_valid, reason = nil, negated_reason = nil, args = [])
+        def initialize(is_valid, reason = nil, args = [])
           @is_valid = is_valid
           @reason = reason
-          @negated_reason = negated_reason
           @args = args
         end
       end

--- a/lib/rspec/graphql_response/validators/validation_runner.rb
+++ b/lib/rspec/graphql_response/validators/validation_runner.rb
@@ -12,8 +12,7 @@ module RSpec
 
         def fail_validation(type, *args)
           message = validator.failure_message(type)
-          negated_message = validator.failure_message_negated(type)
-          ValidationResult.fail(message, negated_message, args)
+          ValidationResult.fail(message, args)
         end
 
         def pass_validation

--- a/spec/graphql_response/matchers/have_errors_spec.rb
+++ b/spec/graphql_response/matchers/have_errors_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe RSpec::GraphQLResponse, "matcher#have_errors", type: :graphql do
         expect(response).to have_errors(2)
       }.to raise_error("Expected response to have 2 errors, but found 1")
     end
+
+    it "invalidates when expecting not to have errors" do
+      expect { 
+        expect(response).to_not have_errors
+      }.to raise_error("Expected response not to have errors, but found\n\t[\"No query string was present\"]")
+    end
   end
 
   context "without errors" do

--- a/spec/graphql_response/validators/have_errors_negated_spec.rb
+++ b/spec/graphql_response/validators/have_errors_negated_spec.rb
@@ -1,0 +1,160 @@
+RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
+  let(:expected_messages) { [] }
+  let(:expected_count) { nil }
+  let(:response) do
+    {
+      "errors" => [{"message" => "No query string was present"}]
+    }
+  end
+
+  let(:not_have_errors) do
+    validator = described_class.validator(:have_errors)
+
+    validator.validate_negated(
+      response,
+      expected_messages: expected_messages,
+      expected_count: expected_count,
+    )
+  end
+
+  let(:actual_messages) do
+    response.fetch("errors", []).map{ |e| e["message"] }
+  end
+
+  let(:actual_count) do
+    response.fetch("errors", []).length
+  end
+
+  context "nil response" do
+    let(:response) { }
+
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.negated_reason).to eq("Cannot evaluate nil for errors")
+    end
+  end
+
+  context "with errors" do
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
+    end
+  end
+
+  context "no errors" do
+    let(:response) { {} }
+
+    it "is valid" do
+      expect(not_have_errors.valid?).to be_truthy
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
+    end
+  end
+
+  context "correct message expected" do
+    let(:expected_messages) { ["No query string was present"] }
+
+    it "is valid" do
+      expect(not_have_errors.valid?).to be_truthy
+    end
+  end
+
+  context "too many expected messages" do
+    let(:expected_messages) { ["No query string was present", "Error 2"] }
+    
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    end
+
+    it "provides a negated reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    end
+  end
+
+  context "incorrect message expected" do
+    let(:expected_messages) { ["wrong error message"] }
+
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    end
+
+    it "provides a negated reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    end
+  end
+
+  context "with expected error count matching actual error count" do
+    let(:expected_count) { 1 }
+
+    it "is valid" do
+      expect(not_have_errors.valid?).to be_truthy
+    end
+  end
+
+  context "with expected error count not matching actual error count" do
+    let(:expected_count) { 2 }
+
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.reason).to eq("Expected response to have #{expected_count} errors, but found #{actual_count}")
+    end
+
+    it "provides a negated reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}")
+    end
+  end
+
+  context "with unmatched error count and unmatched messages" do
+    let(:expected_count) { 3 }
+    let(:expected_messages) { ["No query string was present", "Error 2"] }
+
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides the unmatched error count reason" do
+      expect(not_have_errors.reason).to eq("Expected response to have #{expected_count} errors, but found #{actual_count}")
+    end
+
+    it "provides the negated unmatched error count reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}")
+    end
+  end
+
+  context "with matched error count and unmatched messages" do
+    let(:expected_count) { 1 }
+    let(:expected_messages) { ["No query string was present", "Error 2"] }
+
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides the unmatched error count reason" do
+      expect(not_have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    end
+
+    it "provides the negated unmatched error count reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    end
+  end
+end
+

--- a/spec/graphql_response/validators/have_errors_negated_spec.rb
+++ b/spec/graphql_response/validators/have_errors_negated_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{response["errors"].inspect}")
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
     end
   end
 
@@ -53,13 +53,10 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     it "is valid" do
       expect(not_have_errors.valid?).to be_truthy
     end
-
-    it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
-    end
   end
 
-  context "correct message expected" do
+  context "message expected not to be there" do
+    let(:response) { {} }
     let(:expected_messages) { ["No query string was present"] }
 
     it "is valid" do
@@ -75,68 +72,37 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
-    end
-
-    it "provides a negated reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
-    end
-  end
-
-  context "incorrect message expected" do
-    let(:expected_messages) { ["wrong error message"] }
-
-    it "is not valid" do
-      expect(not_have_errors.valid?).to be_falsey
-    end
-
-    it "provides a reason" do
-      expect(not_have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
-    end
-
-    it "provides a negated reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.negated_reason).to eq("Expected not to find any of\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
   end
 
   context "with expected error count matching actual error count" do
     let(:expected_count) { 1 }
 
-    it "is valid" do
-      expect(not_have_errors.valid?).to be_truthy
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}\n\t#{actual_messages}")
     end
   end
 
   context "with expected error count not matching actual error count" do
     let(:expected_count) { 2 }
 
-    it "is not valid" do
-      expect(not_have_errors.valid?).to be_falsey
-    end
-
-    it "provides a reason" do
-      expect(not_have_errors.reason).to eq("Expected response to have #{expected_count} errors, but found #{actual_count}")
-    end
-
-    it "provides a negated reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}")
+    it "is valid" do
+      expect(not_have_errors.valid?).to be_truthy
     end
   end
 
   context "with unmatched error count and unmatched messages" do
     let(:expected_count) { 3 }
-    let(:expected_messages) { ["No query string was present", "Error 2"] }
+    let(:expected_messages) { ["Error 1", "Error 2"] }
 
-    it "is not valid" do
-      expect(not_have_errors.valid?).to be_falsey
-    end
-
-    it "provides the unmatched error count reason" do
-      expect(not_have_errors.reason).to eq("Expected response to have #{expected_count} errors, but found #{actual_count}")
-    end
-
-    it "provides the negated unmatched error count reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}")
+    it "is valid" do
+      expect(not_have_errors.negated_reason).to be_nil
+      expect(not_have_errors.valid?).to be_truthy
     end
   end
 
@@ -149,11 +115,20 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides the unmatched error count reason" do
-      expect(not_have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}\n\t#{actual_messages.inspect}")
+    end
+  end
+
+  context "with unmatched error count and matched messages" do
+    let(:expected_count) { 2 }
+    let(:expected_messages) { ["No query string was present"] }
+
+    it "is not valid" do
+      expect(not_have_errors.valid?).to be_falsey
     end
 
-    it "provides the negated unmatched error count reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+    it "provides the unmatched error message reason" do
+      expect(not_have_errors.negated_reason).to eq("Expected not to find any of\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
   end
 end

--- a/spec/graphql_response/validators/have_errors_negated_spec.rb
+++ b/spec/graphql_response/validators/have_errors_negated_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Cannot evaluate nil for errors")
+      expect(not_have_errors.reason).to eq("Cannot evaluate nil for errors")
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected not to find any of\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.reason).to eq("Expected not to find any of\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}\n\t#{actual_messages}")
+      expect(not_have_errors.reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}\n\t#{actual_messages}")
     end
   end
 
@@ -101,7 +101,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     let(:expected_messages) { ["Error 1", "Error 2"] }
 
     it "is valid" do
-      expect(not_have_errors.negated_reason).to be_nil
+      expect(not_have_errors.reason).to be_nil
       expect(not_have_errors.valid?).to be_truthy
     end
   end
@@ -115,7 +115,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides the unmatched error count reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}\n\t#{actual_messages.inspect}")
     end
   end
 
@@ -128,7 +128,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides the unmatched error message reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected not to find any of\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.reason).to eq("Expected not to find any of\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
   end
 end

--- a/spec/graphql_response/validators/have_errors_negated_spec.rb
+++ b/spec/graphql_response/validators/have_errors_negated_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RSpec::GraphQLResponse, "validator#not_have_errors" do
     end
 
     it "provides a reason" do
-      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
+      expect(not_have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{response["errors"].inspect}")
     end
   end
 

--- a/spec/graphql_response/validators/have_errors_spec.rb
+++ b/spec/graphql_response/validators/have_errors_spec.rb
@@ -40,10 +40,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
     it "provides a reason" do
       expect(have_errors.reason).to eq("Cannot evaluate nil for errors")
     end
-
-    it "provides a negated reason" do
-      expect(have_errors.negated_reason).to eq("Cannot evaluate nil for errors")
-    end
   end
 
   context "no errors" do
@@ -55,10 +51,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
 
     it "provides a reason" do
       expect(have_errors.reason).to eq("Expected response to have errors, but found none")
-    end
-
-    it "provides a negated reason" do
-      expect(have_errors.negated_reason).to eq("Expected response not to have errors, but found\n\t#{actual_messages.inspect}")
     end
   end
 
@@ -80,10 +72,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
     it "provides a reason" do
       expect(have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
-
-    it "provides a negated reason" do
-      expect(have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
-    end
   end
 
   context "incorrect message expected" do
@@ -95,10 +83,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
 
     it "provides a reason" do
       expect(have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
-    end
-
-    it "provides a negated reason" do
-      expect(have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
   end
 
@@ -120,10 +104,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
     it "provides a reason" do
       expect(have_errors.reason).to eq("Expected response to have #{expected_count} errors, but found #{actual_count}")
     end
-
-    it "provides a negated reason" do
-      expect(have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}")
-    end
   end
 
   context "with unmatched error count and unmatched messages" do
@@ -137,10 +117,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
     it "provides the unmatched error count reason" do
       expect(have_errors.reason).to eq("Expected response to have #{expected_count} errors, but found #{actual_count}")
     end
-
-    it "provides the negated unmatched error count reason" do
-      expect(have_errors.negated_reason).to eq("Expected response not to have #{expected_count} errors, but found #{actual_count}")
-    end
   end
 
   context "with matched error count and unmatched messages" do
@@ -153,10 +129,6 @@ RSpec.describe RSpec::GraphQLResponse, "validator#have_errors" do
 
     it "provides the unmatched error count reason" do
       expect(have_errors.reason).to eq("Expected\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
-    end
-
-    it "provides the negated unmatched error count reason" do
-      expect(have_errors.negated_reason).to eq("Expected not to find\n\t#{expected_messages.inspect}\nbut found\n\t#{actual_messages.inspect}")
     end
   end
 end


### PR DESCRIPTION
this PR adds the core feature set to `.validate_negated` and implements the `.to_not have_errors` matcher negated. it also simplifies failure message registration and retrieval, removing the separate method for registering negated messages in favor of just pre-pending `:negated_<whatever>` in front of the message

all code and specs updated to use the negated form, including the validator and matcher for `have_errors`