### PR TITLE
Add validator specs

### DIFF
--- a/lib/rspec/graphql_response/validators.rb
+++ b/lib/rspec/graphql_response/validators.rb
@@ -11,6 +11,11 @@ module RSpec
       @validators[name] = validator_class
     end
 
+    def self.remove_validator(name)
+      @validators ||= {}
+      @validators.delete(:key)
+    end
+
     def self.validator(name)
       @validators[name].new
     end

--- a/spec/graphql_response/validators/add_validator_spec.rb
+++ b/spec/graphql_response/validators/add_validator_spec.rb
@@ -7,46 +7,111 @@ RSpec.describe RSpec::GraphQLResponse, "#add_validator" do
       failure_message :negated_example, "example negated failure message"
       failure_message :negated_does_not_pass, "negated does not pass"
 
-      validate do |actual, fail_example: false, fail_negated_example: false|
+      validate do |actual, fail_example: false|
         next fail_validation(:example) if fail_example
-        next fail_validation(:negated_example) if fail_negated_example
 
         actual = actual || {}
         it_passes = actual.fetch("pass", false)
+        next fail_validation(:does_not_pass) unless it_passes
 
         pass_validation
       end
 
-      validate_negated do |actual, fail_example: false, fail_negated_example: false|
-        next fail_validation(:example) unless fail_example
-        next fail_validation(:negated_example) unless fail_negated_example
+      validate_negated do |actual, fail_negated_example: false|
+        next fail_validation(:negated_example) if fail_negated_example
 
         actual = actual || {}
         it_passes = actual.fetch("pass", false)
-
-        fail_validation(:negated_does_not_pass) if it_passes
+        next fail_validation(:negated_does_not_pass) if it_passes
 
         pass_validation
       end
     end
   end
 
-  let(:fail_example) { false }
-  let(:fail_negated_example) { false }
-  let(:actual) { { pass: true } }
+  let(:validator) do
+    RSpec::GraphQLResponse.validator(:test_validator)
+  end
 
   describe "#validate" do
-    subject(:result) do
-      validator = RSpec::GraphQLResponse.validator(:test_validator)
-      validator.validate(
-        actual,
-        fail_example: fail_example,
-        fail_negated_example: fail_negated_example
-      )
+    let(:fail_example) { false }
+
+    let(:actual) do
+      { "pass" => true }
     end
 
-    it "passes validation" do
-      expect(result.valid?).to be_truthy
+    subject(:result) do
+      validator.validate(actual, fail_example: fail_example)
+    end
+
+    context "passes" do
+      it "passes validation" do
+        expect(result.valid?).to be_truthy
+      end
+
+      it "does not provide a reason" do
+        expect(result.reason).to be_nil
+      end
+    end
+
+    context "does not pass" do
+      let(:actual) do
+        { pass: false }
+      end
+
+      it "fails validation" do
+        expect(result.valid?).to be_falsey
+      end
+
+      it "provides a reason" do
+        expect(result.reason).to eq("does not pass")
+      end
+    end
+
+    context "fails example" do
+      let(:fail_example) { true }
+
+      it "does not pass validation" do
+        expect(result.valid?).to be_falsey
+      end
+
+      it "provides a reason" do
+        expect(result.reason).to eq("example failure message")
+      end
+    end
+  end
+
+  describe "#validate_negated" do
+    let(:fail_negated_example) { false }
+
+    let(:actual) do
+      { pass: false }
+    end
+
+    subject(:result) do
+      validator.validate_negated(actual, fail_negated_example: fail_negated_example)
+    end
+
+    context "negated pass" do
+      it "passes negated validation" do
+        expect(result.valid?).to be_truthy
+      end
+
+      it "does not provide a reason" do
+        expect(result.reason).to be_nil
+      end
+    end
+
+    context "fail negated example" do
+      let(:fail_negated_example) { true }
+
+      it "does not validate" do
+        expect(result.valid?).to be_falsey
+      end
+
+      it "provides a reason" do
+        expect(result.reason).to eq("example negated failure message")
+      end
     end
   end
 

--- a/spec/graphql_response/validators/add_validator_spec.rb
+++ b/spec/graphql_response/validators/add_validator_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe RSpec::GraphQLResponse, "#add_validator" do
+  before :all do
+    RSpec::GraphQLResponse.add_validator :test_validator do
+      failure_message :example, "example failure message"
+      failure_message :does_not_pass, "does not pass"
+
+      failure_message :negated_example, "example negated failure message"
+      failure_message :negated_does_not_pass, "negated does not pass"
+
+      validate do |actual, fail_example: false, fail_negated_example: false|
+        next fail_validation(:example) if fail_example
+        next fail_validation(:negated_example) if fail_negated_example
+
+        actual = actual || {}
+        it_passes = actual.fetch("pass", false)
+
+        pass_validation
+      end
+
+      validate_negated do |actual, fail_example: false, fail_negated_example: false|
+        next fail_validation(:example) unless fail_example
+        next fail_validation(:negated_example) unless fail_negated_example
+
+        actual = actual || {}
+        it_passes = actual.fetch("pass", false)
+
+        fail_validation(:negated_does_not_pass) if it_passes
+
+        pass_validation
+      end
+    end
+  end
+
+  let(:fail_example) { false }
+  let(:fail_negated_example) { false }
+  let(:actual) { { pass: true } }
+
+  describe "#validate" do
+    subject(:result) do
+      validator = RSpec::GraphQLResponse.validator(:test_validator)
+      validator.validate(
+        actual,
+        fail_example: fail_example,
+        fail_negated_example: fail_negated_example
+      )
+    end
+
+    it "passes validation" do
+      expect(result.valid?).to be_truthy
+    end
+  end
+
+  after :all do
+    RSpec::GraphQLResponse.remove_validator :test_validator
+  end
+end


### PR DESCRIPTION
specs for `RSpec::GraphQLResponse.add_validator` and the `.validate` and `.validate_negated` methods of validators, along with failure messages and successful validation