### PR TITLE
DSL for configuring execute_graphql query, vars, and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ Custom Matchers:
 * [have_errors](/docs/have_errors.md) - validates errors, or lack of, on the GraphQL response
 * [have_operation]() - **COMING SOON** - validates the presence of a specified graphql operation in the graphql response
 
-Helper Methods:
+Context / Describe Helper Methods:
 * [execute_graphql](/docs/execute_graphql.md) - executes a graphql call with the registered schema, query, variables and context
+* [graphql_query](/docs/execute_graphql.md) - the query to execute
+* [graphql_variables](/docs/execute_graphql.md) - a hash of variables the query expects
+* [graphql_context](/docs/execute_graphql.md) - the `context` of a query or mutation's resolver
+
+Spec Helper Methods:
 * [response](/docs/response.md) - the response, as JSON, of the executed graphql query
 * [operation](/docs/operation.md) - retrieves the results of a named operation from the GraphQL response
 

--- a/docs/execute_graphql.md
+++ b/docs/execute_graphql.md
@@ -1,3 +1,43 @@
 # Executing GraphQL with Helper Method `execute_graphql`
 
+Simplifies execution of a graphql query, using `context` / `describe` level helper
+methods for configuring the query.
 
+```ruby
+RSPec.describe Cool::Stuff, type: :graphql do
+  graphql_query <<-GQL
+    query SomeThing($name: String) {
+      characters(name: $name) {
+        id
+        name
+      }
+    }
+  GQL
+  
+  graphql_variables {
+    name: "Jam"
+  }
+
+  grapql_context {
+    current_user: "some user or whatever you need"
+  }
+
+  it "executes and does the thing with the vars and context" do
+    # ... expect things here
+  end
+end
+```
+
+## Available Configuration Methods
+
+### `graphql_query`
+
+A string - most commonly a ruby heredoc - for the graphql query to execute
+
+### `graphql_variables`
+
+A hash of keys and values that the query expects to use
+
+### `graphql_context`
+
+A hash of keys and values that are passed to a query or mutation, as `context`, in that query or mutation's resolver method.

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -1,6 +1,6 @@
 module RSpec
   module GraphQLResponse
-    def self.add_helper(name, &helper)
+    def self.add_helper(name, scope: :spec, &helper)
       helper_module = Module.new do |mod|
         mod.define_method(name) do |*args|
           @result ||= self.instance_exec(*args, &helper)
@@ -11,9 +11,17 @@ module RSpec
         config.after(:each) do
           helper_module.instance_variable_set(:@result, nil)
         end
-      end
 
-      self.include(helper_module)
+        module_method = if scope == :spec
+                          :include
+                        elsif scope == :describe
+                          :extend
+                        else
+                          raise ArgumentError, "A helper method's scope must be either :spec or :describe"
+                        end
+
+        config.send(module_method, helper_module, type: :graphql)
+      end
     end
   end
 end

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -36,6 +36,7 @@ end
 # describe level helpers
 require_relative "helpers/graphql_query"
 require_relative "helpers/graphql_variables"
+require_relative "helpers/graphql_context"
 
 # spec level helpers
 require_relative "helpers/operation"

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -1,5 +1,9 @@
 module RSpec
   module GraphQLResponse
+    def self.add_context_helper(name, &helper)
+      self.add_helper(name, scope: :context, &helper)
+    end
+
     def self.add_helper(name, scope: :spec, &helper)
       helper_module = Module.new do |mod|
         mod.define_method(name) do |*args|
@@ -21,7 +25,7 @@ module RSpec
 
         module_method = if scope == :spec
                           :include
-                        elsif scope == :describe
+                        elsif scope == :context
                           :extend
                         else
                           raise ArgumentError, "A helper method's scope must be either :spec or :describe"

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -29,3 +29,4 @@ end
 require_relative "helpers/operation"
 require_relative "helpers/response"
 require_relative "helpers/execute_graphql"
+require_relative "helpers/graphql_query"

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -3,7 +3,14 @@ module RSpec
     def self.add_helper(name, scope: :spec, &helper)
       helper_module = Module.new do |mod|
         mod.define_method(name) do |*args|
-          @result ||= self.instance_exec(*args, &helper)
+          instance_var = "@#{name}".to_sym
+
+          if self.instance_variables.include? instance_var
+            return self.instance_variable_get(instance_var)
+          end
+
+          result = self.instance_exec(*args, &helper)
+          self.instance_variable_set(instance_var, result)
         end
       end
 
@@ -26,7 +33,11 @@ module RSpec
   end
 end
 
+# describe level helpers
+require_relative "helpers/graphql_query"
+require_relative "helpers/graphql_variables"
+
+# spec level helpers
 require_relative "helpers/operation"
 require_relative "helpers/response"
 require_relative "helpers/execute_graphql"
-require_relative "helpers/graphql_query"

--- a/lib/rspec/graphql_response/helpers/execute_graphql.rb
+++ b/lib/rspec/graphql_response/helpers/execute_graphql.rb
@@ -3,8 +3,10 @@ RSpec::GraphQLResponse.add_helper :execute_graphql do
 
   query = self.class.instance_variable_get(:@graphql_query)
   query_vars = self.class.instance_variable_get(:@graphql_variables)
+  query_context = self.class.instance_variable_get(:@graphql_context)
 
   config.graphql_schema.execute(query, {
-    variables: query_vars
+    variables: query_vars,
+    context: query_context
   })
 end

--- a/lib/rspec/graphql_response/helpers/execute_graphql.rb
+++ b/lib/rspec/graphql_response/helpers/execute_graphql.rb
@@ -1,4 +1,6 @@
 RSpec::GraphQLResponse.add_helper :execute_graphql do
   config = RSpec::GraphQLResponse.configuration
+
+  query = self.class.instance_variable_get(:@graphql_query)
   config.graphql_schema.execute(query)
 end

--- a/lib/rspec/graphql_response/helpers/execute_graphql.rb
+++ b/lib/rspec/graphql_response/helpers/execute_graphql.rb
@@ -2,5 +2,9 @@ RSpec::GraphQLResponse.add_helper :execute_graphql do
   config = RSpec::GraphQLResponse.configuration
 
   query = self.class.instance_variable_get(:@graphql_query)
-  config.graphql_schema.execute(query)
+  query_vars = self.class.instance_variable_get(:@graphql_variables)
+
+  config.graphql_schema.execute(query, {
+    variables: query_vars
+  })
 end

--- a/lib/rspec/graphql_response/helpers/graphql_context.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_context.rb
@@ -1,0 +1,3 @@
+RSpec::GraphQLResponse.add_helper :graphql_context, scope: :describe do |ctx|
+  @graphql_context = ctx
+end

--- a/lib/rspec/graphql_response/helpers/graphql_context.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_context.rb
@@ -1,3 +1,3 @@
-RSpec::GraphQLResponse.add_helper :graphql_context, scope: :describe do |ctx|
+RSpec::GraphQLResponse.add_context_helper :graphql_context do |ctx|
   @graphql_context = ctx
 end

--- a/lib/rspec/graphql_response/helpers/graphql_query.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_query.rb
@@ -1,3 +1,3 @@
-RSpec::GraphQLResponse.add_helper :graphql_query, scope: :describe do |gql|
+RSpec::GraphQLResponse.add_context_helper :graphql_query do |gql|
   @graphql_query = gql
 end

--- a/lib/rspec/graphql_response/helpers/graphql_query.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_query.rb
@@ -1,0 +1,3 @@
+RSpec::GraphQLResponse.add_helper :graphql_query, scope: :describe do |gql|
+  @graphql_query = gql
+end

--- a/lib/rspec/graphql_response/helpers/graphql_variables.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_variables.rb
@@ -1,3 +1,3 @@
-RSpec::GraphQLResponse.add_helper :graphql_variables, scope: :describe do |vars|
+RSpec::GraphQLResponse.add_context_helper :graphql_variables do |vars|
   @graphql_variables = vars
 end

--- a/lib/rspec/graphql_response/helpers/graphql_variables.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_variables.rb
@@ -1,0 +1,3 @@
+RSpec::GraphQLResponse.add_helper :graphql_variables, scope: :describe do |vars|
+  @graphql_variables = vars
+end

--- a/spec/graphql/queries/characters.rb
+++ b/spec/graphql/queries/characters.rb
@@ -2,21 +2,29 @@ module Queries
   class Characters < GraphQL::Schema::Resolver
     type [Types::Response::Character], null: false
 
-    def resolve
-      [
+    argument :name, String, required: false
+
+    def resolve(name: nil)
+      data = [
         {
-          id: 1,
-          name: "Jam"
+          "id" => "1",
+          "name" => "Jam"
         },
         {
-          id: 2,
-          name: "Redemption"
+          "id" => "2",
+          "name" => "Redemption"
         },
         {
-          id: 3,
-          name: "Pet"
+          "id" => "3",
+          "name" => "Pet"
         }
       ]
+
+      if name
+        data.select { |c| c["name"] == name }
+      else
+        data
+      end
     end
   end
 end

--- a/spec/graphql/queries/characters.rb
+++ b/spec/graphql/queries/characters.rb
@@ -20,6 +20,11 @@ module Queries
         }
       ]
 
+      current_user = context[:current_user]
+      if current_user
+        data << {"id" => "4", "name" => current_user }
+      end
+
       if name
         data.select { |c| c["name"] == name }
       else

--- a/spec/graphql_response/helpers/execute_graphql_spec.rb
+++ b/spec/graphql_response/helpers/execute_graphql_spec.rb
@@ -1,19 +1,17 @@
 RSpec.describe RSpec::GraphQLResponse, "helper#execute_graphql", type: :graphql do
-  let(:query) do
-    <<-GQL
-        query {
-          characters {
-            id,
-            name
-          }
-        }
-    GQL
-  end
+  graphql_query <<-GQL
+    query {
+      characters {
+        id,
+        name
+      }
+    }
+  GQL
 
   it "can execute graphql using a let(:query)" do
     response = execute_graphql.to_h
-
     expect(response).to_not be_nil
+
     expect(response["data"]).to include(
       "characters" => [
         { "id" => "1", "name" => "Jam" },

--- a/spec/graphql_response/helpers/graphql_context_spec.rb
+++ b/spec/graphql_response/helpers/graphql_context_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe RSpec::GraphQLResponse, "graphql_variables helper", type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList($name: String) {
+      characters(name: $name) {
+        id
+        name
+      }
+    }
+  GQL
+
+  graphql_context({
+    current_user: "Bitter"
+  })
+
+  it "uses the supplied variables to execute the graphql query" do
+    expect(response).to_not have_errors
+
+    expect(response["data"]).to include(
+      "characters" => [
+        { "id" => "1", "name" => "Jam" },
+        { "id" => "2", "name" => "Redemption" },
+        { "id" => "3", "name" => "Pet" },
+        { "id" => "4", "name" => "Bitter" }
+      ]
+    )
+  end
+end

--- a/spec/graphql_response/helpers/graphql_query_spec.rb
+++ b/spec/graphql_response/helpers/graphql_query_spec.rb
@@ -10,8 +10,13 @@ RSpec.describe RSpec::GraphQLResponse, "graphql_query helper", type: :graphql do
 
   it "executes the supplied graphql query" do
     expect(response).to_not have_errors
-    expect(response["data"]["characters"]).to_not be_nil
 
-    # expect(response).to have_operation(:characters)
+    expect(response["data"]).to include(
+      "characters" => [
+        { "id" => "1", "name" => "Jam" },
+        { "id" => "2", "name" => "Redemption" },
+        { "id" => "3", "name" => "Pet" }
+      ]
+    )
   end
 end

--- a/spec/graphql_response/helpers/graphql_query_spec.rb
+++ b/spec/graphql_response/helpers/graphql_query_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe RSpec::GraphQLResponse, "graphql_query helper", type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList {
+      characters {
+        id
+        name
+      }
+    }
+  GQL
+
+  it "executes the supplied graphql query" do
+    expect(response).to_not have_errors
+    expect(response["data"]["characters"]).to_not be_nil
+
+    # expect(response).to have_operation(:characters)
+  end
+end

--- a/spec/graphql_response/helpers/graphql_variables_spec.rb
+++ b/spec/graphql_response/helpers/graphql_variables_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe RSpec::GraphQLResponse, "graphql_variables helper", type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList($name: String) {
+      characters(name: $name) {
+        id
+        name
+      }
+    }
+  GQL
+
+  graphql_variables({
+    "name" => "Jam"
+  })
+
+  it "uses the supplied variables to execute the graphql query" do
+    expect(response).to_not have_errors
+
+    expect(response["data"]).to include(
+      "characters" => [
+        { "id" => "1", "name" => "Jam" },
+      ]
+    )
+  end
+end

--- a/spec/graphql_response/helpers/operation_spec.rb
+++ b/spec/graphql_response/helpers/operation_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe RSpec::GraphQLResponse, "helper#operation", type: :graphql do
   context "graphql response with no data" do
-    let(:query) { }
-
     it "returns nil" do
       characters = operation(:characters)
 
@@ -10,16 +8,14 @@ RSpec.describe RSpec::GraphQLResponse, "helper#operation", type: :graphql do
   end
 
   context "graphql response with data" do
-    let(:query) do
-      <<-GQL
-        query {
-          characters {
-            id,
-            name
-          }
+    graphql_query <<-GQL
+      query {
+        characters {
+          id,
+          name
         }
-      GQL
-    end
+      }
+    GQL
 
     it "retrieves the named operation from the graphql response" do
       characters = operation(:characters)

--- a/spec/graphql_response/helpers/response_spec.rb
+++ b/spec/graphql_response/helpers/response_spec.rb
@@ -1,14 +1,12 @@
 RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
-  let(:query) do
-    <<-GQL
-        query {
-          characters {
-            id,
-            name
-          }
-        }
-    GQL
-  end
+  graphql_query <<-GQL
+    query {
+      characters {
+        id,
+        name
+      }
+    }
+  GQL
 
   it "uses execute_graphql to create a response" do
     expect(self).to receive(:execute_graphql).once.and_call_original


### PR DESCRIPTION
this PR adds a DSL to `type: :graphql` specs, to include a DSL for configuring the spec's query, variables, and context.

```ruby
RSPec.describe Cool::Stuff, type: :graphql do
  graphql_query <<-GQL
    query SomeThing($name: String) {
      characters(name: $name) {
        id
        name
      }
    }
  GQL
  
  graphql_variables({
    name: "Jam"
  })

  grapql_context({
    current_user: "some user or whatever you need"
  })

  it "executes and does the thing with the vars and context" do
    # ... expect things here
  end
end
```