### PR TITLE
fix: require path for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test rspec-graphql_response
-on: [push, pull_request]
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,11 @@
 name: Test rspec-graphql_response
-on:
-  pull_request:
-  push:
-  paths-ignore:
-    - README.md
-    - CODE_OF_CONDUCT.md
-    - LICENSE.txt
-    - 'docs/**'
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler_cache: true
-      - run: bin/rspec
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+    - run: bin/rspec

--- a/lib/rspec/graphql_response.rb
+++ b/lib/rspec/graphql_response.rb
@@ -1,4 +1,4 @@
-require "RSpec"
+require "rspec"
 
 require_relative "graphql_response/version"
 require_relative "graphql_response/configuration"


### PR DESCRIPTION
# What?
- `paths-ignore` was deprecated so it needed to be removed
-  Simplified the overall config.
- `require "RSpec"` was not valid in CI due to strict naming.