### PR TITLE
add have_operation matcher, validator, and misc other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configuration:
 
 Custom Matchers:
 * [have_errors](/docs/have_errors.md) - validates errors, or lack of, on the GraphQL response
-* [have_operation]() - **COMING SOON** - validates the presence of a specified graphql operation in the graphql response
+* [have_operation](/docs/have_operation.md) - validates the presence of a specified graphql operation in the graphql response
 
 Context / Describe Helper Methods:
 * [execute_graphql](/docs/execute_graphql.md) - executes a graphql call with the registered schema, query, variables and context

--- a/docs/have_operation.md
+++ b/docs/have_operation.md
@@ -1,1 +1,46 @@
 # Validate a response operation with `have_operation(name)`
+
+Check for the presence of an operation's results. Useful when you want to ensure an operation exists before
+retrieving the operation's results.
+
+## Validate an Operation is Present
+
+```ruby
+RSpec.describe My::Characters, type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList {
+      characters {
+        id
+        name
+      }
+    }
+  GQL
+
+  it "has the characters" do
+
+    expect(response).to have_operation(:characters)
+
+  end
+end
+```
+
+## Validate an operation is NOT Present
+
+```ruby
+RSpec.describe My::Characters, type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList {
+      characters {
+        id
+        name
+      }
+    }
+  GQL
+
+  it "does not have books" do
+
+    expect(response).to_not have_operation(:books)
+
+  end
+end
+```

--- a/docs/have_operation.md
+++ b/docs/have_operation.md
@@ -1,0 +1,1 @@
+# Validate a response operation with `have_operation(name)`

--- a/lib/rspec/graphql_response/helpers/execute_graphql.rb
+++ b/lib/rspec/graphql_response/helpers/execute_graphql.rb
@@ -1,9 +1,13 @@
 RSpec::GraphQLResponse.add_helper :execute_graphql do
   config = RSpec::GraphQLResponse.configuration
 
-  query = self.class.instance_variable_get(:@graphql_query)
-  query_vars = self.class.instance_variable_get(:@graphql_variables)
-  query_context = self.class.instance_variable_get(:@graphql_context)
+  klass = self.class
+  has_var = klass.method(:class_variable_defined?)
+  get_var = klass.method(:class_variable_get)
+
+  query = get_var.call(:@@graphql_query) if has_var.call(:@@graphql_query)
+  query_vars = get_var.call(:@@graphql_variables) if has_var.call(:@@graphql_variables)
+  query_context = get_var.call(:@@graphql_context) if has_var.call(:@@graphql_context)
 
   config.graphql_schema.execute(query, {
     variables: query_vars,

--- a/lib/rspec/graphql_response/helpers/execute_graphql.rb
+++ b/lib/rspec/graphql_response/helpers/execute_graphql.rb
@@ -1,13 +1,9 @@
 RSpec::GraphQLResponse.add_helper :execute_graphql do
   config = RSpec::GraphQLResponse.configuration
 
-  klass = self.class
-  has_var = klass.method(:class_variable_defined?)
-  get_var = klass.method(:class_variable_get)
-
-  query = get_var.call(:@@graphql_query) if has_var.call(:@@graphql_query)
-  query_vars = get_var.call(:@@graphql_variables) if has_var.call(:@@graphql_variables)
-  query_context = get_var.call(:@@graphql_context) if has_var.call(:@@graphql_context)
+  query = self.class.instance_variable_get(:@graphql_query)
+  query_vars = self.class.instance_variable_get(:@graphql_variables)
+  query_context = self.class.instance_variable_get(:@graphql_context)
 
   config.graphql_schema.execute(query, {
     variables: query_vars,

--- a/lib/rspec/graphql_response/helpers/execute_graphql.rb
+++ b/lib/rspec/graphql_response/helpers/execute_graphql.rb
@@ -1,9 +1,9 @@
 RSpec::GraphQLResponse.add_helper :execute_graphql do
   config = RSpec::GraphQLResponse.configuration
 
-  query = self.class.instance_variable_get(:@graphql_query)
-  query_vars = self.class.instance_variable_get(:@graphql_variables)
-  query_context = self.class.instance_variable_get(:@graphql_context)
+  query = get_graphql_query if respond_to? :get_graphql_query
+  query_vars = get_graphql_variables if respond_to? :get_graphql_variables
+  query_context = get_graphql_context if respond_to? :get_graphql_context
 
   config.graphql_schema.execute(query, {
     variables: query_vars,

--- a/lib/rspec/graphql_response/helpers/graphql_context.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_context.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_context do |ctx|
-  @@graphql_context = ctx
+  self.define_method(:get_graphql_context) { ctx }
 end

--- a/lib/rspec/graphql_response/helpers/graphql_context.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_context.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_context do |ctx|
-  @graphql_context = ctx
+  @@graphql_context = ctx
 end

--- a/lib/rspec/graphql_response/helpers/graphql_query.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_query.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_query do |gql|
-  @graphql_query = gql
+  @@graphql_query = gql
 end

--- a/lib/rspec/graphql_response/helpers/graphql_query.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_query.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_query do |gql|
-  @graphql_query = gql
+  self.define_method(:get_graphql_query) { gql }
 end

--- a/lib/rspec/graphql_response/helpers/graphql_query.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_query.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_query do |gql|
-  @@graphql_query = gql
+  @graphql_query = gql
 end

--- a/lib/rspec/graphql_response/helpers/graphql_variables.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_variables.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_variables do |vars|
-  @@graphql_variables = vars
+  self.define_method(:get_graphql_variables) { vars }
 end

--- a/lib/rspec/graphql_response/helpers/graphql_variables.rb
+++ b/lib/rspec/graphql_response/helpers/graphql_variables.rb
@@ -1,3 +1,3 @@
 RSpec::GraphQLResponse.add_context_helper :graphql_variables do |vars|
-  @graphql_variables = vars
+  @@graphql_variables = vars
 end

--- a/lib/rspec/graphql_response/matchers.rb
+++ b/lib/rspec/graphql_response/matchers.rb
@@ -12,3 +12,4 @@ module RSpec
 end
 
 require_relative "matchers/have_errors"
+require_relative "matchers/have_operation"

--- a/lib/rspec/graphql_response/matchers/have_errors.rb
+++ b/lib/rspec/graphql_response/matchers/have_errors.rb
@@ -11,7 +11,7 @@ RSpec::GraphQLResponse.add_matcher :have_errors do |count = nil|
     @result.valid?
   end
 
-  failure_message do |response|
+  failure_message do |_|
     @result.reason
   end
 
@@ -27,7 +27,7 @@ RSpec::GraphQLResponse.add_matcher :have_errors do |count = nil|
     @result.valid?
   end
 
-  failure_message_when_negated do |response|
+  failure_message_when_negated do |_|
     @result.reason
   end
 

--- a/lib/rspec/graphql_response/matchers/have_operation.rb
+++ b/lib/rspec/graphql_response/matchers/have_operation.rb
@@ -1,0 +1,23 @@
+RSpec::GraphQLResponse.add_matcher :have_operation do |operation_name|
+  match do |response|
+    validator = RSpec::GraphQLResponse.validator(:have_operation)
+
+    @result = validator.validate(response, operation_name: operation_name)
+    @result.valid?
+  end
+
+  failure_message do |_|
+    @result.reason
+  end
+
+  match_when_negated do |response|
+    validator = RSpec::GraphQLResponse.validator(:have_operation)
+
+    @result = validator.validate_negated(response, operation_name: operation_name)
+    @result.valid?
+  end
+
+  failure_message_when_negated do |_|
+    @result.reason
+  end
+end

--- a/lib/rspec/graphql_response/validators.rb
+++ b/lib/rspec/graphql_response/validators.rb
@@ -23,3 +23,4 @@ module RSpec
 end
 
 require_relative "validators/have_errors"
+require_relative "validators/have_operation"

--- a/lib/rspec/graphql_response/validators/have_operation.rb
+++ b/lib/rspec/graphql_response/validators/have_operation.rb
@@ -5,8 +5,19 @@ RSpec::GraphQLResponse.add_validator :have_operation do
   validate do |response, operation_name:|
     next fail_validation(:nil) unless response.is_a? Hash
 
-    op = response.dig("data", operation_name)
+    op = response.dig("data", operation_name.to_s)
     next fail_validation(:not_found, operation_name, response) if op.nil?
+
+    pass_validation
+  end
+
+  failure_message :found, ->(expected, actual) { "Expected not to find operation result named #{expected}, but found it\n\t#{actual}" }
+
+  validate_negated do |response, operation_name:|
+    next fail_validation(:nil) unless response.is_a? Hash
+
+    op = response.dig("data", operation_name.to_s)
+    next fail_validation(:found, operation_name, response) unless op.nil?
 
     pass_validation
   end

--- a/lib/rspec/graphql_response/validators/have_operation.rb
+++ b/lib/rspec/graphql_response/validators/have_operation.rb
@@ -1,0 +1,13 @@
+RSpec::GraphQLResponse.add_validator :have_operation do
+  failure_message :nil, "Cannot evaluate operations on nil"
+  failure_message :not_found, ->(expected, actual) { "Expected to find operation result named #{expected}, but did not find it\n\t#{actual}" }
+
+  validate do |response, operation_name:|
+    next fail_validation(:nil) unless response.is_a? Hash
+
+    op = response.dig("data", operation_name)
+    next fail_validation(:not_found, operation_name, response) if op.nil?
+
+    pass_validation
+  end
+end

--- a/spec/graphql_response/helpers/execute_graphql_spec.rb
+++ b/spec/graphql_response/helpers/execute_graphql_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe RSpec::GraphQLResponse, "helper#execute_graphql", type: :graphql 
     }
   GQL
 
-  it "can execute graphql using a let(:query)" do
-    response = execute_graphql.to_h
-    expect(response).to_not be_nil
+  it "can execute graphql" do
+    expect(response).to_not have_errors
 
     expect(response["data"]).to include(
       "characters" => [

--- a/spec/graphql_response/helpers/graphql_query_spec.rb
+++ b/spec/graphql_response/helpers/graphql_query_spec.rb
@@ -19,4 +19,18 @@ RSpec.describe RSpec::GraphQLResponse, "graphql_query helper", type: :graphql do
       ]
     )
   end
+
+  context "nested context" do
+    it "still works" do
+      expect(response).to_not have_errors
+
+      expect(response["data"]).to include(
+        "characters" => [
+          { "id" => "1", "name" => "Jam" },
+          { "id" => "2", "name" => "Redemption" },
+          { "id" => "3", "name" => "Pet" }
+        ]
+      )
+    end
+  end
 end

--- a/spec/graphql_response/matchers/have_operation_spec.rb
+++ b/spec/graphql_response/matchers/have_operation_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe RSpec::GraphQLResponse, "matcher#have_operation", type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList {
+      characters {
+        id
+        name
+      }
+    }
+  GQL
+
+  context "operation present" do
+    it "is valid" do
+      expect(response).to_not have_errors
+
+      expect(response).to have_operation(:characters)
+    end
+
+    it "is invalid when negated" do
+      expect(response).to_not have_errors
+
+      expect { 
+        expect(response).to_not have_operation(:characters)
+      }.to raise_error(/Expected not to find operation result named characters/)
+    end
+  end
+
+  context "operation not present" do
+    it "is invalid" do
+      expect(response).to_not have_errors
+
+      expect {
+        expect(response).to have_operation(:operation_not_present)
+      }.to raise_error(/Expected to find operation result named operation_not_present/)
+    end
+
+    it "is valid when negated" do
+      expect(response).to_not have_errors
+
+      expect(response).to_not have_operation(:operation_not_present)
+    end
+  end
+end

--- a/spec/graphql_response/validators/have_operation_negated_spec.rb
+++ b/spec/graphql_response/validators/have_operation_negated_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe RSpec::GraphQLResponse, "#have_operation validator", type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList {
+      characters {
+        id
+        name
+      }
+    }
+  GQL
+
+  let(:operation_name) { :operation_does_not_exist }
+
+  subject(:result) do
+    validator = RSpec::GraphQLResponse.validator :have_operation
+    validator.validate_negated(response, operation_name: operation_name)
+  end
+
+  it "validates the operation result is not present" do
+    expect(response).not_to have_errors
+    expect(result.valid?).to be_truthy
+  end
+
+  context "nil response" do
+    let(:response) { nil }
+
+    it "fails validation when response is nil" do
+      expect(result.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(result.reason).to eq("Cannot evaluate operations on nil")
+    end
+  end
+
+  context "operation is found" do
+    let(:operation_name) { :characters }
+
+    it "fails validation" do
+      expect(response).not_to have_errors
+      expect(result.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(result.reason).to eq("Expected not to find operation result named #{operation_name}, but found it\n\t#{response}")
+    end
+  end
+end

--- a/spec/graphql_response/validators/have_operation_negated_spec.rb
+++ b/spec/graphql_response/validators/have_operation_negated_spec.rb
@@ -8,16 +8,11 @@ RSpec.describe RSpec::GraphQLResponse, "#have_operation validator", type: :graph
     }
   GQL
 
-  let(:operation_name) { :operation_does_not_exist }
+  let(:operation_name) { nil }
 
   subject(:result) do
     validator = RSpec::GraphQLResponse.validator :have_operation
     validator.validate_negated(response, operation_name: operation_name)
-  end
-
-  it "validates the operation result is not present" do
-    expect(response).not_to have_errors
-    expect(result.valid?).to be_truthy
   end
 
   context "nil response" do
@@ -29,6 +24,15 @@ RSpec.describe RSpec::GraphQLResponse, "#have_operation validator", type: :graph
 
     it "provides a reason" do
       expect(result.reason).to eq("Cannot evaluate operations on nil")
+    end
+  end
+
+  context "operation not present" do
+    let(:operation_name) { :operation_does_not_exist }
+
+    it "validates the operation result is not present" do
+      expect(response).not_to have_errors
+      expect(result.valid?).to be_truthy
     end
   end
 

--- a/spec/graphql_response/validators/have_operation_spec.rb
+++ b/spec/graphql_response/validators/have_operation_spec.rb
@@ -8,15 +8,11 @@ RSpec.describe RSpec::GraphQLResponse, "#have_operation validator", type: :graph
     }
   GQL
 
-  let(:operation_name) { "characters" }
+  let(:operation_name) { nil }
 
   subject(:result) do
     validator = RSpec::GraphQLResponse.validator :have_operation
     validator.validate(response, operation_name: operation_name)
-  end
-
-  it "validates the operation result is present" do
-    expect(result.valid?).to be_truthy
   end
 
   context "nil response" do
@@ -28,6 +24,14 @@ RSpec.describe RSpec::GraphQLResponse, "#have_operation validator", type: :graph
 
     it "provides a reason" do
       expect(result.reason).to eq("Cannot evaluate operations on nil")
+    end
+  end
+
+  context "operation present" do
+    let(:operation_name) { :characters }
+
+    it "validates the operation result is present" do
+      expect(result.valid?).to be_truthy
     end
   end
 

--- a/spec/graphql_response/validators/have_operation_spec.rb
+++ b/spec/graphql_response/validators/have_operation_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe RSpec::GraphQLResponse, "#have_operation validator", type: :graphql do
+  graphql_query <<-GQL
+    query CharacterList {
+      characters {
+        id
+        name
+      }
+    }
+  GQL
+
+  let(:operation_name) { "characters" }
+
+  subject(:result) do
+    validator = RSpec::GraphQLResponse.validator :have_operation
+    validator.validate(response, operation_name: operation_name)
+  end
+
+  it "validates the operation result is present" do
+    expect(result.valid?).to be_truthy
+  end
+
+  context "nil response" do
+    let(:response) { nil }
+
+    it "fails validation when response is nil" do
+      expect(result.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(result.reason).to eq("Cannot evaluate operations on nil")
+    end
+  end
+
+  context "operation not found" do
+    let(:operation_name) { :operation_that_does_not_exist }
+
+    it "fails validation when response is nil" do
+      expect(result.valid?).to be_falsey
+    end
+
+    it "provides a reason" do
+      expect(result.reason).to eq("Expected to find operation result named #{operation_name}, but did not find it\n\t#{response}")
+    end
+  end
+end


### PR DESCRIPTION
adds a `have_operation` matcher

corrects several issues regarding context level helpers for graphql configuration

many adjustments to specs and adding nested context spec for graphql execution

in the process of writing this PR, i found out the previous implementations of the `graphql_query` and other graphql config methods did not work with nested `describe` and `context` blocks, due to the way instance variables work. after a lot of trial and error, i finally found a way that i believe works as intended. you'll notice in this PR the adjustment of `graphql_query`, `graphql_variables` and `graphql_context` helper methods and use inside of `execute_graphql`. you'll also notice an addition of a nested `context` inside of the `execute_graphql` specs to ensure it works correctly.