### PR TITLE
feat: response_data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    attr_extras (6.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.4.4)
     graphql (1.12.5)
     method_source (1.0.0)
+    optimist (3.0.1)
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -33,6 +37,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
+    super_diff (0.6.1)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
 
 PLATFORMS
   ruby
@@ -43,6 +51,7 @@ DEPENDENCIES
   pry-byebug (~> 3.8)
   rake (>= 12.0)
   rspec-graphql_response!
+  super_diff (~> 0.6)
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-graphql_response (0.4.0)
+    rspec-graphql_response (0.4.1)
       graphql (>= 1.0)
       rspec (>= 3.0)
 
@@ -12,7 +12,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.4.4)
-    graphql (1.12.5)
+    graphql (1.12.6)
     method_source (1.0.0)
     optimist (3.0.1)
     patience_diff (1.2.0)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Spec Helper Methods:
 
 - [execute_graphql](/docs/execute_graphql.md) - executes a graphql call with the registered schema, query, variables and context
 - [response](/docs/response.md) - the response, as JSON, of the executed graphql query
-- [operation](/docs/operation.md) - retrieves the results of a named operation from the GraphQL response
+- [response_data](/docs/response_data.md) - digs through the graphql response to return data from the specified node(s)
 
 API / Development
 

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -1,38 +1,3 @@
 # Using the `operation` helper
 
-The `operation` helper will dig through a response to find a data
-structure that looks like, 
-
-```ruby
-{
-  "data" => {
-    operation_name
-  }
-}
-```
-
-## Basic Use
-
-```ruby
-it "has characters" do
-  characters = operation(:characters)
-
-  expect(character).to include(
-    { id: 1, name: "Jam" },
-    # ...
-  )
-end
-```
-
-## Handling Nil
-
-If there is no `"data"` or no named operation for the name supplied, the
-`operation` helper will return `nil`
-
-```ruby
-it "returns nil if operation doesn't exist" do
-  character = operation(:something_that_does_not_exist)
-
-  expect(operation).to be_nil
-end
-```
+Deprecated. See [response_data](response_data.md) instead.

--- a/docs/response.md
+++ b/docs/response.md
@@ -1,1 +1,1 @@
-# Check the GraphQL Response with Helper `response`
+# The GraphQL Response, via Helper `response`

--- a/docs/response_data.md
+++ b/docs/response_data.md
@@ -7,7 +7,7 @@ and all layers of hash and array.
 ## Syntax
 
 ```ruby
-response_data *dig_pattern
+response_data *[dig_pattern]
 ```
 
 Data returned via this helper will assume a `"data" => ` key at the root of
@@ -16,19 +16,23 @@ of attributes for the `dig_pattern`.
 
 ### Params
 
-* \*dig_pattern - an array of attributes (symbol, string, or key/value pair) that describes
+* `*[dig_pattern]` - an array of attributes (`:symbol`, `"string"`, or `key: :value` pair) that describes
 the data structure to dig through, and thefinal data set to retrieve from the graphql response.
 
 #### dig_pattern
 
 Each attribute added to the `dig_pattern` represents an attribute at the given level of the
-data structure. 
+data structure, in numeric order from left to right. The first attribute provides will dig into
+that attribute at the first level of data (just below the `"data" =>` key). The second attribute
+will dig through data just below that first level, etc. etc. etc.
 
 For example, with a data structure as shown below, in "Basic Use", you could specifiy these
 attributes for the dig pattern:
 
 * :characters
 * :name
+
+Like this:
 
 ```ruby
 response_data :characters, :name

--- a/docs/response_data.md
+++ b/docs/response_data.md
@@ -1,0 +1,107 @@
+# Using the `response_data` Helper
+
+The `response_data` helper will dig through a graphql response, through
+the outer hash, into the response data for an operation, and through any
+and all layers of hash and array. 
+
+## Basic Use
+
+A `response` data structure may look something like the following.
+
+```ruby
+{
+  "data" => {
+    "characters" => [
+      { "id" => "1", "name" => "Jam" },
+      { "id" => "2", "name" => "Redemption" },
+      { "id" => "3", "name" => "Pet" }
+    ]
+  }
+}
+```
+
+The `response_data` helper will dig through to give you simplified
+results that are easier to verify.
+
+For example, if only the names of the characters need to be checked:
+
+```ruby
+response_data :characters, :name
+
+# => ["Jam", "Redemption", "Pet"]
+```
+
+Or perhaps only the name for 2nd character is needed:
+
+```ruby
+response_data {characters: [1]}, :name
+
+# => "Redemption"
+```
+
+## List Every Item in an Array
+
+Many responses from a graphql call will include an array of data somewhere
+in the data structure. If you need to return all of the items in an array,
+you only need to specify that array's key:
+
+```ruby
+it "has characters" do
+  characters = response_data(:characters)
+
+  expect(character).to include(
+    { id: 1, name: "Jam" },
+    # ...
+  )
+end
+```
+
+## Dig a Field From Every Item in an Array
+
+When validation only needs to occur on a specific field for items found in
+an array, there are two options.
+
+1. Specify a list of fields as already shown
+2. change the array's key to a hash and provide a `:symbol` wrapped in an array as the value
+
+The first option was already shown in the Basic Use section above. 
+
+```ruby
+response_data :characters, :name
+
+# => ["Jam", "Redemption", "Pet"]
+```
+
+For the second option, the code would look like this:
+
+```ruby
+response_data characters: [:name]
+
+# => ["Jam", "Redemption", "Pet"]
+```
+
+Both of these options are functionaly the same. The primary difference will be
+how you wish to express the data structure in your code. Changing the list of
+attributes to a hash with an array wrapping the value will provide a better
+indication that an array is expected at that point in the data structure.
+
+## Dig Out an Item By Index, From an Array
+
+There may be times when only a single piece of a returned array needs to be
+validated. To handle this, switch the key of the array to a hash, as in the
+previous example. Rather than specifying a child node's key in the value, though,
+specify the index of the item you wish to extract.
+
+```ruby
+response_data characters: [1]
+```
+
+This will return the character at index 1, from the array of characters.
+
+## Handling Nil
+
+If there is no data the key supplied, the helper will return `nil`
+
+```ruby
+response_data(:something_that_does_not_exist) #=> nil
+```

--- a/docs/response_data.md
+++ b/docs/response_data.md
@@ -4,6 +4,41 @@ The `response_data` helper will dig through a graphql response, through
 the outer hash, into the response data for an operation, and through any
 and all layers of hash and array. 
 
+## Syntax
+
+```ruby
+response_data *dig_pattern
+```
+
+Data returned via this helper will assume a `"data" => ` key at the root of
+the `response` object. This root does not need to be specified in the list
+of attributes for the `dig_pattern`.
+
+### Params
+
+* \*dig_pattern - an array of attributes (symbol, string, or key/value pair) that describes
+the data structure to dig through, and thefinal data set to retrieve from the graphql response.
+
+#### dig_pattern
+
+Each attribute added to the `dig_pattern` represents an attribute at the given level of the
+data structure. 
+
+For example, with a data structure as shown below, in "Basic Use", you could specifiy these
+attributes for the dig pattern:
+
+* :characters
+* :name
+
+```ruby
+response_data :characters, :name
+```
+
+This dig pattern will find the `"characters"` key just below `"data"`, then iterate through
+the array of characters and retrieve the `"name"` of each character.
+
+For more details and options for the dig pattern, see the examples below.
+
 ## Basic Use
 
 A `response` data structure may look something like the following.

--- a/docs/response_data.md
+++ b/docs/response_data.md
@@ -17,7 +17,7 @@ of attributes for the `dig_pattern`.
 ### Params
 
 * `*[dig_pattern]` - an array of attributes (`:symbol`, `"string"`, or `key: :value` pair) that describes
-the data structure to dig through, and thefinal data set to retrieve from the graphql response.
+the data structure to dig through, and the final data set to retrieve from the graphql response.
 
 #### dig_pattern
 

--- a/lib/rspec/graphql_response.rb
+++ b/lib/rspec/graphql_response.rb
@@ -1,5 +1,6 @@
 require "rspec"
 
+require_relative "graphql_response/dig_dug/dig_dug"
 require_relative "graphql_response/version"
 require_relative "graphql_response/configuration"
 require_relative "graphql_response/validators"

--- a/lib/rspec/graphql_response/dig_dug/dig_dug.rb
+++ b/lib/rspec/graphql_response/dig_dug/dig_dug.rb
@@ -1,7 +1,21 @@
 module RSpec
   module GraphQLResponse
     class DigDug
+      attr_reader :dig_pattern
 
+      def initialize(dig_pattern)
+        @dig_pattern = parse_dig_pattern(dig_pattern)
+      end
+
+      def dig(data)
+        data[dig_pattern]
+      end
+
+      private
+
+      def parse_dig_pattern(pattern)
+        pattern[0].to_s
+      end
     end
   end
 end

--- a/lib/rspec/graphql_response/dig_dug/dig_dug.rb
+++ b/lib/rspec/graphql_response/dig_dug/dig_dug.rb
@@ -22,6 +22,7 @@ module RSpec
         if node[:type] == :symbol
           result = dig_symbol(data, node[:key])
         elsif node[:type] == :array
+          binding.pry
           child_data = data[node[:key].to_s]
           result = dig_symbol(child_data, node[:value])
         end

--- a/lib/rspec/graphql_response/dig_dug/dig_dug.rb
+++ b/lib/rspec/graphql_response/dig_dug/dig_dug.rb
@@ -33,20 +33,21 @@ module RSpec
         pattern_config = pattern.map do |pattern_item|
           if pattern_item.is_a? Symbol 
             {
-                type: :symbol,
-                key: pattern_item
-              }
-          elsif pattern_item.is_a? Hash
-            pattern_key = pattern_item.keys[0]
-            pattern_value = pattern_item.values[0][0]
-
-            {
-              type: :array,
-              key: pattern_key,
-              value: pattern_value
+              type: :symbol,
+              key: pattern_item
             }
+          elsif pattern_item.is_a? Hash
+            pattern_item.map do |key, value|
+              {
+                type: :array,
+                key: key,
+                value: value[0]
+              }
+            end
           end
         end
+
+        pattern_config.flatten
       end
 
       def dig_symbol(data, key)

--- a/lib/rspec/graphql_response/dig_dug/dig_dug.rb
+++ b/lib/rspec/graphql_response/dig_dug/dig_dug.rb
@@ -1,0 +1,7 @@
+module RSpec
+  module GraphQLResponse
+    class DigDug
+
+    end
+  end
+end

--- a/lib/rspec/graphql_response/dig_dug/dig_dug.rb
+++ b/lib/rspec/graphql_response/dig_dug/dig_dug.rb
@@ -3,18 +3,44 @@ module RSpec
     class DigDug
       attr_reader :dig_pattern
 
-      def initialize(dig_pattern)
-        @dig_pattern = parse_dig_pattern(dig_pattern)
+      def initialize(*dig_pattern)
+        @dig_pattern = parse_dig_pattern(*dig_pattern)
       end
 
       def dig(data)
-        data[dig_pattern]
+        dig_data(data, dig_pattern)
       end
 
       private
 
-      def parse_dig_pattern(pattern)
-        pattern[0].to_s
+      def dig_data(data, patterns)
+        return data if patterns.nil?
+        return data if patterns.empty?
+
+        node = patterns[0]
+        result = node[:operation].call(data, node[:key])
+
+        dig_data(result, patterns.drop(1))
+      end
+
+      def parse_dig_pattern(*pattern)
+        pattern_config = pattern.map do |pattern_item|
+          {
+            key: pattern_item.to_s,
+            operation: self.method(:dig_symbol)
+          }
+        end
+      end
+
+      def dig_symbol(data, key)
+        return data[key.to_s] if data.is_a? Hash
+
+        if data.is_a? Array
+          mapped_data = data.map { |value| value[key.to_s] }
+          return mapped_data.flatten
+        end
+
+        return data
       end
     end
   end

--- a/lib/rspec/graphql_response/dig_dug/dig_dug.rb
+++ b/lib/rspec/graphql_response/dig_dug/dig_dug.rb
@@ -18,13 +18,24 @@ module RSpec
         return data if patterns.empty?
 
         node = patterns[0]
+        node_key = node[:key]
+        node_key = node_key.to_s if node_key.is_a? Symbol
+        node_value = node[:value]
 
         if node[:type] == :symbol
-          result = dig_symbol(data, node[:key])
+          result = dig_symbol(data, node_key)
         elsif node[:type] == :array
-          binding.pry
-          child_data = data[node[:key].to_s]
-          result = dig_symbol(child_data, node[:value])
+          if data.is_a? Hash
+            child_data = data[node_key]
+            result = dig_symbol(child_data, node_value)
+          elsif data.is_a? Array
+            result = data.map { |value|
+              child_data = value[node_key]
+              dig_symbol(child_data, node_value)
+            }.compact
+          else
+            result = data
+          end
         end
 
         dig_data(result, patterns.drop(1))

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -42,7 +42,6 @@ end
 # describe level helpers
 require_relative "helpers/graphql_context"
 require_relative "helpers/graphql_operation"
-require_relative "helpers/graphql_query"
 require_relative "helpers/graphql_variables"
 
 # spec level helpers

--- a/lib/rspec/graphql_response/helpers.rb
+++ b/lib/rspec/graphql_response/helpers.rb
@@ -40,11 +40,13 @@ module RSpec
 end
 
 # describe level helpers
-require_relative "helpers/graphql_operation"
-require_relative "helpers/graphql_variables"
 require_relative "helpers/graphql_context"
+require_relative "helpers/graphql_operation"
+require_relative "helpers/graphql_query"
+require_relative "helpers/graphql_variables"
 
 # spec level helpers
+require_relative "helpers/execute_graphql"
 require_relative "helpers/operation"
 require_relative "helpers/response"
-require_relative "helpers/execute_graphql"
+require_relative "helpers/response_data"

--- a/lib/rspec/graphql_response/helpers/operation.rb
+++ b/lib/rspec/graphql_response/helpers/operation.rb
@@ -1,4 +1,5 @@
 RSpec::GraphQLResponse.add_helper :operation do |name|
+  warn 'WARNING: operation has been deprecated in favor of response_data. This helper will be removed in v0.5'
   return nil unless response.is_a? Hash
 
   response.dig("data", name.to_s)

--- a/lib/rspec/graphql_response/helpers/response_data.rb
+++ b/lib/rspec/graphql_response/helpers/response_data.rb
@@ -1,30 +1,45 @@
 RSpec::GraphQLResponse.add_helper :response_data do |*fields|
   next nil unless response.is_a? Hash
 
-  field_count = fields.compact.count
   response_data = response["data"]
+  next response_data if fields.compact.count == 0
 
-  next response_data if field_count == 0
+  # must pre-declare these to make the references valid by lexical scope
+  dig_deep = nil
+  dig_data = nil
 
-  dig_data = ->(data, field_index) do
+  # dig the value of field (as field_list[field_index]) out of data
+  dig_data = ->(data, field_index, field_list) do
+    field = field_list[field_index]
+
+    # handle `characters: [1]` for arrays of values
+    # handle `characters: [:friends]` for a hash within arrays
+    if field.is_a? Hash
+      hash_keys = field.keys
+      first_key = hash_keys[0]
+      data_value = data[first_key.to_s]
+      data = dig_deep.call(data_value, 1, hash_keys)
+      return data
+    end
+
     # dig through the array at the current field index
-    return data.map { |v| dig_data.call(v, field_index) } if data.is_a? Array
+    return data.map { |v| dig_data.call(v, field_index, field_list) } if data.is_a? Array
 
     # it's not an array or hash, so exit
     return data unless data.is_a? Hash
 
     # it's a hash, so dig into the data
-    field = fields[field_index]
     return data[field.to_s]
   end
 
-  dig_deep = ->(data, field_index) do
+  dig_deep = ->(data, field_index, field_list) do
+    field_count = field_list.count
     return data if field_index >= field_count
 
-    result = dig_data.call(data, field_index)
-    dig_deep.call(result, field_index + 1)
+    result = dig_data.call(data, field_index, field_list)
+    dig_deep.call(result, field_index + 1, field_list)
   end
     
-  result = dig_deep.call(response_data, 0)
+  result = dig_deep.call(response_data, 0, fields.compact)
   Array(result).flatten
 end

--- a/lib/rspec/graphql_response/helpers/response_data.rb
+++ b/lib/rspec/graphql_response/helpers/response_data.rb
@@ -1,0 +1,3 @@
+RSpec::GraphQLResponse.add_helper :response_data do
+  execute_graphql.to_h
+end

--- a/lib/rspec/graphql_response/helpers/response_data.rb
+++ b/lib/rspec/graphql_response/helpers/response_data.rb
@@ -2,54 +2,12 @@ RSpec::GraphQLResponse.add_helper :response_data do |*fields|
   next nil unless response.is_a? Hash
 
   response_data = response["data"]
-  next response_data if fields.compact.count == 0
+  next nil if response_data.nil?
+  next nil if response_data.empty?
 
-  # must pre-declare these to make the references valid by lexical scope
-  dig_deep = nil
-  dig_data = nil
+  fields = fields.compact
+  next response_data if fields.empty?
 
-  # dig the value of field (as field_list[field_index]) out of data
-  dig_data = ->(data, field_index, field_list) do
-    field = field_list[field_index]
-
-    # handle `characters: [1]` for arrays of values
-    # handle `characters: [:friends]` for a hash within arrays
-    if field.is_a? Hash
-      field.each do |key, value|
-        data_value = data[key.to_s]
-
-        value = value[0]
-        value = value.to_s if value.is_a? Symbol
-
-        data_value = data_value.map {|h| h[value]} if value.is_a? String
-        data_value = data_value[value] if value.is_a? Numeric
-        data = data_value
-      end
-
-      return data
-    end
-
-    # dig through the array at the current field index
-    return data.map { |v| dig_data.call(v, field_index, field_list) } if data.is_a? Array
-
-    # it's not an array or hash, so exit
-    return data unless data.is_a? Hash
-
-    # it's a hash, so dig into the data
-    return data[field.to_s]
-  end
-
-  dig_deep = ->(data, field_index, field_list) do
-    return data if field_list.nil?
-
-    field_count = field_list.count
-    return data if field_index >= field_count
-
-    result = dig_data.call(data, field_index, field_list)
-    dig_deep.call(result, field_index + 1, field_list)
-  end
-    
-  result = dig_deep.call(response_data, 0, fields.compact)
-  result = result.flatten if result.is_a? Array
-  result
+  dig_dug = RSpec::GraphQLResponse::DigDug.new(*fields)
+  dig_dug.dig(response_data)
 end

--- a/lib/rspec/graphql_response/helpers/response_data.rb
+++ b/lib/rspec/graphql_response/helpers/response_data.rb
@@ -1,5 +1,30 @@
 RSpec::GraphQLResponse.add_helper :response_data do |*fields|
-  return nil unless response.is_a? Hash
+  next nil unless response.is_a? Hash
 
-  response.dig(*([:data, *fields].compact).map {|field| field.to_s})
+  field_count = fields.compact.count
+  response_data = response["data"]
+
+  next response_data if field_count == 0
+
+  dig_data = ->(data, field_index) do
+    # dig through the array at the current field index
+    return data.map { |v| dig_data.call(v, field_index) } if data.is_a? Array
+
+    # it's not an array or hash, so exit
+    return data unless data.is_a? Hash
+
+    # it's a hash, so dig into the data
+    field = fields[field_index]
+    return data[field.to_s]
+  end
+
+  dig_deep = ->(data, field_index) do
+    return data if field_index >= field_count
+
+    result = dig_data.call(data, field_index)
+    dig_deep.call(result, field_index + 1)
+  end
+    
+  result = dig_deep.call(response_data, 0)
+  Array(result).flatten
 end

--- a/lib/rspec/graphql_response/helpers/response_data.rb
+++ b/lib/rspec/graphql_response/helpers/response_data.rb
@@ -1,3 +1,5 @@
-RSpec::GraphQLResponse.add_helper :response_data do
-  execute_graphql.to_h
+RSpec::GraphQLResponse.add_helper :response_data do |*fields|
+  return nil unless response.is_a? Hash
+
+  response.dig(*([:data, *fields].compact).map {|field| field.to_s})
 end

--- a/lib/rspec/graphql_response/version.rb
+++ b/lib/rspec/graphql_response/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module GraphQLResponse
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/rspec-graphql_response.gemspec
+++ b/rspec-graphql_response.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 12.0"
   spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "pry-byebug", "~> 3.8"
+  spec.add_development_dependency "super_diff", "~> 0.6"
 
   spec.add_runtime_dependency "rspec", ">= 3.0"
   spec.add_runtime_dependency "graphql", ">= 1.0"

--- a/spec/graphql/queries/characters.rb
+++ b/spec/graphql/queries/characters.rb
@@ -10,22 +10,22 @@ module Queries
           "id" => "1",
           "name" => "Jam",
           "friends" => [
-            { "name" => "Redemption" }
+            { "id" => "2", "name" => "Redemption" }
           ]
         },
         {
           "id" => "2",
           "name" => "Redemption",
           "friends" => [
-            { "name" => "Pet" },
-            { "name" => "Jam" }
+            { "id" => "1", "name" => "Jam" },
+            { "id" => "3", "name" => "Pet" }
           ]
         },
         {
           "id" => "3",
           "name" => "Pet",
           "friends" => [
-            { "name" => "Redemption" }
+            { "id" => "2", "name" => "Redemption" }
           ]
         }
       ]

--- a/spec/graphql/queries/characters.rb
+++ b/spec/graphql/queries/characters.rb
@@ -3,6 +3,7 @@ module Queries
     type [Types::Response::Character], null: false
 
     argument :name, String, required: false
+    argument :friend, [Types::Response::Character], null: false, required: false
 
     def resolve(name: nil)
       data = [

--- a/spec/graphql/queries/characters.rb
+++ b/spec/graphql/queries/characters.rb
@@ -3,21 +3,30 @@ module Queries
     type [Types::Response::Character], null: false
 
     argument :name, String, required: false
-    argument :friend, [Types::Response::Character], null: false, required: false
 
     def resolve(name: nil)
       data = [
         {
           "id" => "1",
-          "name" => "Jam"
+          "name" => "Jam",
+          "friends" => [
+            { "name" => "Redemption" }
+          ]
         },
         {
           "id" => "2",
-          "name" => "Redemption"
+          "name" => "Redemption",
+          "friends" => [
+            { "name" => "Pet" },
+            { "name" => "Jam" }
+          ]
         },
         {
           "id" => "3",
-          "name" => "Pet"
+          "name" => "Pet",
+          "friends" => [
+            { "name" => "Redemption" }
+          ]
         }
       ]
 

--- a/spec/graphql/types/response/character.rb
+++ b/spec/graphql/types/response/character.rb
@@ -5,6 +5,7 @@ module Types
 
       field :id, ID, null: false
       field :name, String, null: false
+      field :friends, [Character], null: false
     end
   end
 end

--- a/spec/graphql_response/dig_dug/dig_dug_spec.rb
+++ b/spec/graphql_response/dig_dug/dig_dug_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe RSpec::GraphQLResponse::DigDug do
     end
   end
 
+  context "dig indexed item of value from hash that came through an array" do
+    let(:dig_pattern) { [:characters, friends: [1]] }
+
+    it "returns the correct data" do
+      expect(dig).to include(
+        { "id" => "3", "name" => "Pet" }
+      )
+    end
+  end
+
   context "dig multiple nested levels of hash and Array" do
     let(:dig_pattern) { [:characters, {friends: [0]}, :name] }
 

--- a/spec/graphql_response/dig_dug/dig_dug_spec.rb
+++ b/spec/graphql_response/dig_dug/dig_dug_spec.rb
@@ -1,0 +1,111 @@
+RSpec.describe RSpec::GraphQLResponse::DigDug do
+  let(:response) do
+    {
+      "characters" => [
+        {
+          "id" => "1",
+          "name" => "Jam",
+          "friends" => [
+            { "id" => "2", "name" => "Redemption" }
+          ]
+        },
+        {
+          "id" => "2",
+          "name" => "Redemption",
+          "friends" => [
+            { "id" => "1", "name" => "Jam" },
+            { "id" => "3", "name" => "Pet" }
+          ]
+        },
+        {
+          "id" => "3",
+          "name" => "Pet",
+          "friends" => [
+            { "id" => "2", "name" => "Redemption" }
+          ]
+        }
+      ]
+    }
+  end
+
+  let(:dig_pattern) { nil }
+
+  subject(:dig) do
+    dig_dug = described_class.new(dig_pattern)
+    dig_dug.dig(response)
+  end
+
+  context "dig one layer" do
+    let(:dig_pattern) { [:characters] }
+
+    it "returns the correct data" do
+      expect(dig).to include(
+        {
+          "id" => "1",
+          "name" => "Jam",
+          "friends" => [
+            { "id" => "2", "name" => "Redemption" }
+          ]
+        },
+        {
+          "id" => "2",
+          "name" => "Redemption",
+          "friends" => [
+            { "id" => "1", "name" => "Jam" },
+            { "id" => "3", "name" => "Pet" }
+          ]
+        },
+        {
+          "id" => "3",
+          "name" => "Pet",
+          "friends" => [
+            { "id" => "2", "name" => "Redemption" }
+          ]
+        }
+      )
+    end
+  end
+
+  it "can dig through an array" do
+    expect(response_data :characters, :friends).to include(
+      { "id" => "2", "name" => "Redemption" },
+      { "id" => "1", "name" => "Jam" },
+      { "id" => "3", "name" => "Pet" },
+      { "id" => "2", "name" => "Redemption" }
+    )
+  end
+
+  it "can dig through an array to nested fields" do
+    expect(response_data :characters, :friends, :name).to include(
+      "Redemption",
+      "Jam",
+      "Pet"
+    )
+  end
+
+  it "can dig into an Array at the specified index" do
+    expect(response_data characters: [1]).to eq(
+      "id" => "2",
+      "name" => "Redemption",
+      "friends" => [
+        { "id" => "1", "name" => "Jam" },
+        { "id" => "3", "name" => "Pet" }
+      ]
+    )
+  end
+
+  it "can dig multiple levels into an Array at the specified index" do
+    expect(response_data characters: [1], friends: [0]).to include(
+      { "id" => "1", "name" => "Jam" },
+    )
+  end
+
+  it "can dig into a Hash that came through an Array" do
+    expect(response_data characters: [0], friends: [:name]).to eq(["Redemption"])
+  end
+
+  it "can dig multiple nested levels of hash and Array" do
+    expect(response_data(:characters, {friends: [0]}, :name)).to eq "Jam"
+  end
+
+end

--- a/spec/graphql_response/dig_dug/dig_dug_spec.rb
+++ b/spec/graphql_response/dig_dug/dig_dug_spec.rb
@@ -66,46 +66,69 @@ RSpec.describe RSpec::GraphQLResponse::DigDug do
     end
   end
 
-  it "can dig through an array" do
-    expect(response_data :characters, :friends).to include(
-      { "id" => "2", "name" => "Redemption" },
-      { "id" => "1", "name" => "Jam" },
-      { "id" => "3", "name" => "Pet" },
-      { "id" => "2", "name" => "Redemption" }
-    )
-  end
+  context "dig through an array" do
+    let(:dig_pattern) { [:characters, :friends] }
 
-  it "can dig through an array to nested fields" do
-    expect(response_data :characters, :friends, :name).to include(
-      "Redemption",
-      "Jam",
-      "Pet"
-    )
-  end
-
-  it "can dig into an Array at the specified index" do
-    expect(response_data characters: [1]).to eq(
-      "id" => "2",
-      "name" => "Redemption",
-      "friends" => [
+    it "returns the correct data" do
+      expect(dig).to include(
+        { "id" => "2", "name" => "Redemption" },
         { "id" => "1", "name" => "Jam" },
-        { "id" => "3", "name" => "Pet" }
-      ]
-    )
+        { "id" => "3", "name" => "Pet" },
+        { "id" => "2", "name" => "Redemption" }
+      )
+    end
   end
 
-  it "can dig multiple levels into an Array at the specified index" do
-    expect(response_data characters: [1], friends: [0]).to include(
-      { "id" => "1", "name" => "Jam" },
-    )
+  context "dig through an array to nested fields" do
+    let(:dig_pattern) { [:characters, :friends, :name] }
+
+    it "returns the correct data" do
+      expect(dig).to include(
+        "Redemption",
+        "Jam",
+        "Pet"
+      )
+    end
   end
 
-  it "can dig into a Hash that came through an Array" do
-    expect(response_data characters: [0], friends: [:name]).to eq(["Redemption"])
+  context "dig into an Array at the specified index" do
+    let(:dig_pattern) { [characters: [1]] }
+
+    it "returns the correct data" do
+      expect(dig).to eq(
+        "id" => "2",
+        "name" => "Redemption",
+        "friends" => [
+          { "id" => "1", "name" => "Jam" },
+          { "id" => "3", "name" => "Pet" }
+        ]
+      )
+    end
   end
 
-  it "can dig multiple nested levels of hash and Array" do
-    expect(response_data(:characters, {friends: [0]}, :name)).to eq "Jam"
+  context "dig multiple levels into an Array at the specified index" do
+    let(:dig_pattern) { [characters: [1], friends: [0]] }
+
+    it "returns the correct data" do
+      expect(dig).to include(
+        { "id" => "1", "name" => "Jam" }
+      )
+    end
   end
 
+  context "dig into a Hash that came through an Array" do
+    let(:dig_pattern) { [characters: [0], friends: [:name]] }
+
+    it "returns the correct data" do
+      expect(dig).to eq(["Redemption"])
+    end
+  end
+
+  context "dig multiple nested levels of hash and Array" do
+    let(:dig_pattern) { [:characters, {friends: [0]}, :name] }
+
+    it "returns the correct data" do
+      expect(dig).to eq "Jam"
+    end
+  end
 end

--- a/spec/graphql_response/dig_dug/dig_dug_spec.rb
+++ b/spec/graphql_response/dig_dug/dig_dug_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RSpec::GraphQLResponse::DigDug do
   let(:dig_pattern) { nil }
 
   subject(:dig) do
-    dig_dug = described_class.new(dig_pattern)
+    dig_dug = described_class.new(*dig_pattern)
     dig_dug.dig(response)
   end
 

--- a/spec/graphql_response/dig_dug/dig_dug_spec.rb
+++ b/spec/graphql_response/dig_dug/dig_dug_spec.rb
@@ -135,10 +135,10 @@ RSpec.describe RSpec::GraphQLResponse::DigDug do
   end
 
   context "dig multiple nested levels of hash and Array" do
-    let(:dig_pattern) { [:characters, {friends: [0]}, :name] }
+    let(:dig_pattern) { [:characters, {friends: [1]}, :name] }
 
     it "returns the correct data" do
-      expect(dig).to eq "Jam"
+      expect(dig).to eq ["Pet"]
     end
   end
 end

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -108,8 +108,7 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
     end
 
     it "can dig multiple nested levels of hash and Array" do
-      expect(response_data(:characters, {friends: [0]}, :name)).to eq "Jam"
+      expect(response_data(:characters, {friends: [1]}, :name)).to eq(["Pet"])
     end
-
   end
 end

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -15,14 +15,57 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
     it "can return the hash" do
       expect(response_data).to include(
         "characters" => [
-          { "id" => "1", "name" => "Jam" },
-          { "id" => "2", "name" => "Redemption" },
-          { "id" => "3", "name" => "Pet" }
+          {
+            "id" => "1",
+            "name" => "Jam",
+            "friends" => [
+              { "name" => "Redemption" }
+            ]
+          },
+          {
+            "id" => "2",
+            "name" => "Redemption",
+            "friends" => [
+              { "name" => "Pet" },
+              { "name" => "Jam" }
+            ]
+          },
+          {
+            "id" => "3",
+            "name" => "Pet",
+            "friends" => [
+              { "name" => "Redemption" }
+            ]
+          }
         ]
       )
     end
 
     it "can dig to a specific layer" do
+      expect(response_data :characters).to include(
+        {
+          "id" => "1",
+          "name" => "Jam",
+          "friends" => [
+            { "name" => "Redemption" }
+          ]
+        },
+        {
+          "id" => "2",
+          "name" => "Redemption",
+          "friends" => [
+            { "name" => "Pet" },
+            { "name" => "Jam" }
+          ]
+        },
+        {
+          "id" => "3",
+          "name" => "Pet",
+          "friends" => [
+            { "name" => "Redemption" }
+          ]
+        }
+      )
     end
   end
 end

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
       )
     end
 
-    it "can dig to a specific layer" do
+    it "can dig to the first layer" do
       expect(response_data :characters).to include(
         {
           "id" => "1",
@@ -66,6 +66,23 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
             { "id" => "2", "name" => "Redemption" }
           ]
         }
+      )
+    end
+
+    it "can dig through an array" do
+      expect(response_data :characters, :friends).to include(
+        { "id" => "2", "name" => "Redemption" },
+        { "id" => "1", "name" => "Jam" },
+        { "id" => "3", "name" => "Pet" },
+        { "id" => "2", "name" => "Redemption" }
+      )
+    end
+
+    it "can dig through an array to nested fields" do
+      expect(response_data :characters, :friends).to include(
+        "Redemption",
+        "Jam",
+        "Pet"
       )
     end
 

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
       expect(response_data characters: [0], friends: [:name]).to eq(["Redemption"])
     end
 
-    xit "can dig multiple nested levels of hash and Array" do
+    it "can dig multiple nested levels of hash and Array" do
       expect(response_data(:characters, {friends: [0]}, :name)).to eq "Jam"
     end
 

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
-  graphql_query <<-GQL
+  graphql_operation <<-GQL
     query {
       characters {
         id,
         name,
         friends {
+          id
           name
         }
       }
@@ -19,22 +20,22 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
             "id" => "1",
             "name" => "Jam",
             "friends" => [
-              { "name" => "Redemption" }
+              { "id" => "2", "name" => "Redemption" }
             ]
           },
           {
             "id" => "2",
             "name" => "Redemption",
             "friends" => [
-              { "name" => "Pet" },
-              { "name" => "Jam" }
+              { "id" => "1", "name" => "Jam" },
+              { "id" => "3", "name" => "Pet" }
             ]
           },
           {
             "id" => "3",
             "name" => "Pet",
             "friends" => [
-              { "name" => "Redemption" }
+              { "id" => "2", "name" => "Redemption" }
             ]
           }
         ]
@@ -47,20 +48,38 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
           "id" => "1",
           "name" => "Jam",
           "friends" => [
-            { "name" => "Redemption" }
+            { "id" => "2", "name" => "Redemption" }
           ]
         },
         {
           "id" => "2",
           "name" => "Redemption",
           "friends" => [
-            { "name" => "Pet" },
-            { "name" => "Jam" }
+            { "id" => "1", "name" => "Jam" },
+            { "id" => "3", "name" => "Pet" }
           ]
         },
         {
           "id" => "3",
           "name" => "Pet",
+          "friends" => [
+            { "id" => "2", "name" => "Redemption" }
+          ]
+        }
+      )
+    end
+
+    it "can dig into an Array at the specified index" do
+      expect(response_data characters: [1], friends: [0]).to include(
+        { "name" => "Pet" },
+      )
+    end
+
+    it "can shape the response" do
+      expect(response_data characters: [0], friends: [:name]).to include(
+        {
+          "id" => "1",
+          "name" => "Jam",
           "friends" => [
             { "name" => "Redemption" }
           ]

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
     end
 
     it "can dig through an array to nested fields" do
-      expect(response_data :characters, :friends).to include(
+      expect(response_data :characters, :friends, :name).to include(
         "Redemption",
         "Jam",
         "Pet"

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -88,20 +88,12 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
 
     it "can dig into an Array at the specified index" do
       expect(response_data characters: [1], friends: [0]).to include(
-        { "id" => "3", "name" => "Pet" },
+        { "id" => "1", "name" => "Jam" },
       )
     end
 
     it "can shape the response" do
-      expect(response_data characters: [0], friends: [:name]).to include(
-        {
-          "id" => "1",
-          "name" => "Jam",
-          "friends" => [
-            { "name" => "Redemption" }
-          ]
-        }
-      )
+      expect(response_data characters: [0], friends: [:name]).to eq(["Redemption"])
     end
   end
 end

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
+  graphql_query <<-GQL
+    query {
+      characters {
+        id,
+        name,
+        friends {
+          name
+        }
+      }
+    }
+  GQL
+
+  context "has data returned" do
+    it "can return the hash" do
+      expect(response_data).to include(
+        "characters" => [
+          { "id" => "1", "name" => "Jam" },
+          { "id" => "2", "name" => "Redemption" },
+          { "id" => "3", "name" => "Pet" }
+        ]
+      )
+    end
+
+    it "can dig to a specific layer" do
+    end
+  end
+end

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
 
     it "can dig into an Array at the specified index" do
       expect(response_data characters: [1], friends: [0]).to include(
-        { "name" => "Pet" },
+        { "id" => "3", "name" => "Pet" },
       )
     end
 

--- a/spec/graphql_response/helpers/response_data_spec.rb
+++ b/spec/graphql_response/helpers/response_data_spec.rb
@@ -87,13 +87,29 @@ RSpec.describe RSpec::GraphQLResponse, "helper#response", type: :graphql do
     end
 
     it "can dig into an Array at the specified index" do
+      expect(response_data characters: [1]).to eq(
+        "id" => "2",
+        "name" => "Redemption",
+        "friends" => [
+          { "id" => "1", "name" => "Jam" },
+          { "id" => "3", "name" => "Pet" }
+        ]
+      )
+    end
+
+    it "can dig multiple levels into an Array at the specified index" do
       expect(response_data characters: [1], friends: [0]).to include(
         { "id" => "1", "name" => "Jam" },
       )
     end
 
-    it "can shape the response" do
+    it "can dig into a Hash that came through an Array" do
       expect(response_data characters: [0], friends: [:name]).to eq(["Redemption"])
     end
+
+    xit "can dig multiple nested levels of hash and Array" do
+      expect(response_data(:characters, {friends: [0]}, :name)).to eq "Jam"
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "pry-byebug"
-
+require "super_diff/rspec"
 require "graphql"
 require "graphql/example_schema"
 require "rspec/graphql_response"


### PR DESCRIPTION
# Why?

Create a helper that enhances the `response` and `operation` ergonomics allowing developers to more easily traverse nested responses.

## Proposal

- `response_data` when called with no arguments would return `.to_h` of `data` object from the GraphQL response
- `response_data(:id)` when called with a symbol it returns the value of `response['data'][:id]`
- `resonse_data(:struct, :sub_field, :nested, ...)` when called with any number of symbols it would have a `.dig`-like experience allowing for deeply nested fields to be returned.
- `response_data(:obj, nested: [0]`) when called returns the value from the specified index of the nested Array
- `response_data(:characters, friends: [:name, :status])` will shape the returned `friends` Array to only include specified fields.